### PR TITLE
Deploy pympv on Windows

### DIFF
--- a/.github/workflows/deploy-windows.yml
+++ b/.github/workflows/deploy-windows.yml
@@ -1,0 +1,74 @@
+name: deploy-windows
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+
+  deploy-binaries:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Download libmpv
+      run: |
+        $VERSION = "libmpv/mpv-dev-x86_64-20191110-git-35de8ea.7z"
+        $URL = "https://sourceforge.net/projects/mpv-player-windows/files"
+        curl -L -o libmpv.7z "$URL/$VERSION"
+        7z x libmpv.7z
+
+    - name: Set VS environment variables
+      run: |
+        $VsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+        echo "::add-path::$VsPath"
+
+    - name: Set MSVC x86_64 linker path
+      run: |
+        $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+        $LinkPath = vswhere -latest -products * -find "$LinkGlob" |
+                    Select-Object -Last 1
+        echo "::add-path::$LinkPath"
+
+    - name: Create the libmpv zip
+      shell: cmd
+      run: |
+        lib /def:mpv.def /machine:x64 /out:mpv.lib
+        ren mpv-1.dll mpv.dll
+        ren include mpv
+        7z a libmpv.zip mpv/ mpv.dll mpv.lib
+
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+        pip install --upgrade cython
+
+    - name: Create Python wheel
+      run: |
+        python setup.py bdist_wheel --plat-name win_amd64 --python-tag cp37
+
+    - name: Get the package version
+      id: data
+      run: |
+        $VERSION = python setup.py --version | Out-String
+        echo "::set-output name=version::$VERSION"
+
+    - name: Create a Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          libmpv.zip
+          dist/pympv-${{ steps.data.outputs.version }}-cp37-cp37m-win_amd64.whl
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: deploy-windows
+name: deploy
 
 on:
   push:
@@ -7,17 +7,17 @@ on:
 
 jobs:
 
-  deploy-binaries:
+  create-windows-wheel:
 
     runs-on: windows-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Download libmpv
       run: |
-        $VERSION = "libmpv/mpv-dev-x86_64-20191110-git-35de8ea.7z"
+        $VERSION = "libmpv/mpv-dev-x86_64-20200524-git-685bd6a.7z"
         $URL = "https://sourceforge.net/projects/mpv-player-windows/files"
         curl -L -o libmpv.7z "$URL/$VERSION"
         7z x libmpv.7z
@@ -58,17 +58,41 @@ jobs:
       run: |
         python setup.py bdist_wheel --plat-name win_amd64 --python-tag cp37
 
-    - name: Get the package version
-      id: data
-      run: |
-        $VERSION = python setup.py --version | Out-String
-        echo "::set-output name=version::$VERSION"
-
-    - name: Create a Release
-      uses: softprops/action-gh-release@v1
+    - name: Upload Windows wheel
+      uses: actions/upload-artifact@v2
       with:
-        files: |
-          libmpv.zip
-          dist/pympv-${{ steps.data.outputs.version }}-cp37-cp37m-win_amd64.whl
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: dist
+        path: dist
+
+  deploy-binaries:
+
+    needs: create-windows-wheel
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Download Windows wheel
+      uses: actions/download-artifact@v2
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools twine
+        pip install --upgrade cython
+
+    - name: Release source code
+      run: |
+        python setup.py sdist
+
+    - name: Twine check
+      run: |
+        python -m twine check dist/*
+
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}

--- a/setup.py
+++ b/setup.py
@@ -14,44 +14,62 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from setuptools import setup, find_packages
-from setuptools.extension import Extension
+import sys
+from glob import glob
+from os.path import join
 
-try:
-    from Cython.Build import cythonize
-    USE_CYTHON = True
-except ImportError:
-    USE_CYTHON = False
+from Cython.Build import cythonize
+from setuptools import Extension, find_packages, setup
 
-ext = 'pyx' if USE_CYTHON else 'c'
-extensions=[
-    Extension('mpv', ['mpv.%s' % ext], libraries=['mpv']),
-]
-if USE_CYTHON:
-    extensions=cythonize(extensions, force=True)
+extra_data = {}
+extensions = [Extension("mpv", ["mpv.pyx"], libraries=["mpv"])]
+
+if set(["setup.py", "--version", "-V"]) >= set(sys.argv):
+    extensions = []
+
+if set(["bdist_wheel", "--plat-name", "win_amd64"]) <= set(sys.argv):
+    extra_data["data_files"] = [
+        ("Scripts", ["mpv.dll"]),
+        ("libs", ["mpv.lib"]),
+        ("include", glob("mpv/*")),
+    ]
+    extensions = [
+        Extension(
+            "mpv",
+            ["mpv.pyx"],
+            libraries=["mpv"],
+            library_dirs=[os.curdir],
+            include_dirs=[join(os.curdir, "mpv")],
+        )
+    ]
+
+extensions = cythonize(extensions, force=True)
+
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 setup(
-        name='pympv',
-        version='0.6.0',
-        description='Python bindings for the libmpv library',
-        # This is supposed to be reST. Cheating by using a common subset of
-        # reST and Markdown...
-        long_description=read('README.md'),
-        author='Andre D',
-        author_email='andre@andred.ca',
-        maintainer='Hector Martin',
-        maintainer_email='marcan@marcan.st',
-        url='https://github.com/marcan/pympv',
-        classifiers=[
-            'Development Status :: 3 - Alpha',
-            'Programming Language :: Cython',
-            'Topic :: Multimedia :: Sound/Audio :: Players',
-            'Topic :: Multimedia :: Video',
-            'Topic :: Software Development :: Libraries',
-            'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)'
-        ],
-        ext_modules=extensions
+    name="pympv",
+    version="0.7.0",
+    description="Python bindings for the libmpv library",
+    # This is supposed to be reST. Cheating by using a common subset of
+    # reST and Markdown...
+    long_description=read("README.md"),
+    author="Andre D",
+    author_email="andre@andred.ca",
+    maintainer="Hector Martin",
+    maintainer_email="marcan@marcan.st",
+    url="https://github.com/marcan/pympv",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Cython",
+        "Topic :: Multimedia :: Sound/Audio :: Players",
+        "Topic :: Multimedia :: Video",
+        "Topic :: Software Development :: Libraries",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    ],
+    ext_modules=extensions,
+    **extra_data
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if set(["bdist_wheel", "--plat-name", "win_amd64"]) <= set(sys.argv):
     extensions = [
         Extension(
             "mpv",
-            ["mpv.pyx"],
+            [extension_src],
             libraries=["mpv"],
             library_dirs=[os.curdir],
             include_dirs=[join(os.curdir, "mpv")],

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,13 @@ import sys
 from glob import glob
 from os.path import join
 
-from Cython.Build import cythonize
 from setuptools import Extension, find_packages, setup
+
+try:
+    from Cython.Build import cythonize
+    USE_CYTHON = True
+except ImportError:
+    USE_CYTHON = False
 
 extra_data = {}
 extensions = [Extension("mpv", ["mpv.pyx"], libraries=["mpv"])]
@@ -43,7 +48,8 @@ if set(["bdist_wheel", "--plat-name", "win_amd64"]) <= set(sys.argv):
         )
     ]
 
-extensions = cythonize(extensions, force=True)
+if USE_CYTHON:
+    extensions = cythonize(extensions, force=True)
 
 
 def read(fname):
@@ -57,6 +63,7 @@ setup(
     # This is supposed to be reST. Cheating by using a common subset of
     # reST and Markdown...
     long_description=read("README.md"),
+    long_description_content_type="text/markdown",
     author="Andre D",
     author_email="andre@andred.ca",
     maintainer="Hector Martin",

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,13 @@ from setuptools import Extension, find_packages, setup
 try:
     from Cython.Build import cythonize
     USE_CYTHON = True
+    extension_src = "mpv.pyx"
 except ImportError:
     USE_CYTHON = False
+    extension_src = "mpv.c"
 
 extra_data = {}
-extensions = [Extension("mpv", ["mpv.pyx"], libraries=["mpv"])]
+extensions = [Extension("mpv", [extension_src], libraries=["mpv"])]
 
 if set(["setup.py", "--version", "-V"]) >= set(sys.argv):
     extensions = []


### PR DESCRIPTION
This PR allows to deploy `pympv` on Windows.

When a new `pympv` version is released, all `libmpv` binaries, in addition to the related `.whl`, are uploaded alongside with the release.

I hope this is appreciated! Thanks in advance for your review! :)