### PR TITLE
Remove support for Python 2

### DIFF
--- a/mpv.pyx
+++ b/mpv.pyx
@@ -52,11 +52,11 @@ cdef extern from "Python.h":
     void PyEval_InitThreads()
 
 # mpv -> Python
-def _strdec(s):
+cdef str _strdec(bytes s):
     return s.decode("utf-8", "surrogateescape")
 
 # Python -> mpv
-def _strenc(s):
+cdef bytes _strenc(str s):
     return s.encode("utf-8", "surrogateescape")
 
 PyEval_InitThreads()

--- a/mpv.pyx
+++ b/mpv.pyx
@@ -49,23 +49,13 @@ if _CAPI_MAJOR != _REQUIRED_CAPI_MAJOR or _CAPI_MINOR < _MIN_CAPI_MINOR:
 cdef extern from "Python.h":
     void PyEval_InitThreads()
 
-_is_py3 = sys.version_info >= (3,)
-_strdec_err = "surrogateescape" if _is_py3 else "strict"
 # mpv -> Python
 def _strdec(s):
-    try:
-        return s.decode("utf-8", _strdec_err)
-    except UnicodeDecodeError:
-        # In python2, bail to bytes on failure
-        return bytes(s)
+    return s.decode("utf-8", "surrogateescape")
 
 # Python -> mpv
 def _strenc(s):
-    try:
-        return s.encode("utf-8", _strdec_err)
-    except UnicodeEncodeError:
-        # In python2, assume bytes and walk right through
-        return s
+    return s.encode("utf-8", "surrogateescape")
 
 PyEval_InitThreads()
 

--- a/mpv.pyx
+++ b/mpv.pyx
@@ -48,9 +48,6 @@ if _CAPI_MAJOR != _REQUIRED_CAPI_MAJOR or _CAPI_MINOR < _MIN_CAPI_MINOR:
             (_REQUIRED_CAPI_MAJOR, _MIN_CAPI_MINOR, _CAPI_MAJOR, _CAPI_MINOR)
     )
 
-cdef extern from "Python.h":
-    void PyEval_InitThreads()
-
 # mpv -> Python
 cdef str _strdec(bytes s):
     return s.decode("utf-8", "surrogateescape")
@@ -59,6 +56,10 @@ cdef str _strdec(bytes s):
 cdef bytes _strenc(str s):
     return s.encode("utf-8", "surrogateescape")
 
+# TODO: Remove this call once Python 3.6 is EOL: it is automatically called by
+# Py_Initialize() since Python 3.7 and will be removed in Python 3.11.
+cdef extern from "Python.h":
+    void PyEval_InitThreads()
 PyEval_InitThreads()
 
 class Errors:

--- a/mpv.pyx
+++ b/mpv.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/mpv.pyx
+++ b/mpv.pyx
@@ -293,7 +293,7 @@ cdef class Event(object):
         return _strdec(name_c)
 
     cdef _init(self, mpv_event* event, ctx):
-        cdef uint64_t ctxid = <uint64_t>id(ctx)
+        ctxid = id(ctx)
         self.id = event.event_id
         self.data = self._data(event)
         userdata = _reply_userdatas[ctxid].get(event.reply_userdata, None)
@@ -333,8 +333,8 @@ class MPVError(Exception):
 class PyMPVError(Exception):
     pass
 
-cdef _callbacks = dict()
-cdef _reply_userdatas = dict()
+cdef dict _callbacks = {}
+cdef dict _reply_userdatas = {}
 
 class _ReplyUserData(object):
     def __init__(self, data):
@@ -723,7 +723,7 @@ cdef class Context(object):
         return pipe
 
     def __cinit__(self):
-        cdef uint64_t ctxid = <uint64_t>id(self)
+        ctxid = id(self)
         with nogil:
             self._ctx = mpv_create()
         if not self._ctx:
@@ -777,7 +777,7 @@ cdef class Context(object):
     def shutdown(self):
         if self._ctx == NULL:
             return
-        cdef uint64_t ctxid = <uint64_t>id(self)
+        ctxid = id(self)
         with nogil:
             mpv_terminate_destroy(self._ctx)
         self.callbackthread.shutdown()


### PR DESCRIPTION
It’s time for Python 2 to retire.

This optimises string handling a bit, since now every `str` is Unicode, and every `bytes` is bytes.

I’ve also removed the conversion to and from `uint64_t` for `ctxid` because `dict` doesn’t have any API to index by this type, making the conversion useless.